### PR TITLE
Fix getting real group name

### DIFF
--- a/src/flask_multipass_keycloak.py
+++ b/src/flask_multipass_keycloak.py
@@ -180,7 +180,7 @@ class KeycloakIdentityProvider(AuthlibIdentityProvider):
     @memoize_request
     def _get_group_data(self, name):
         # API allows searching groups only by name
-        _, real_group_name = name.rsplit(' > ', 1)
+        *_, real_group_name = name.rsplit(' > ', 1)
         group_path = self.group_name_as_path(name)
         params = {'search': real_group_name,
                   'exact': 'true',


### PR DESCRIPTION
This fixes a bug when trying to get the real group name of the root group (ie. without special separator).